### PR TITLE
feat(range,clickable): click to move marker, show range

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -34,7 +34,6 @@ document.addEventListener('DOMContentLoaded', () => {
                         that.setCoordinates(e.latlng);
                     });
                 }
-                console.log('clickable',config);
 
                 this.tile = L.tileLayer(config.tilesUrl, {
                     attribution: config.attribution,

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -9,7 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
             map: null,
             tile: null,
             marker: null,
+            rangeCircle: null,
             drawItems: null,
+            rangeSelectField: null,
 
             createMap: function (el) {
                 const that = this;
@@ -25,6 +27,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (!config.draggable) {
                     this.map.dragging.disable();
                 }
+
+                if(config.clickable)
+                {
+                    this.map.on('click', function(e) {
+                        that.setCoordinates(e.latlng);
+                    });
+                }
+                console.log('clickable',config);
 
                 this.tile = L.tileLayer(config.tilesUrl, {
                     attribution: config.attribution,
@@ -48,7 +58,11 @@ document.addEventListener('DOMContentLoaded', () => {
                         draggable: false,
                         autoPan: true
                     }).addTo(this.map);
-                    this.map.on('move', () => this.marker.setLatLng(this.map.getCenter()));
+                    this.setMarkerRange();
+                    if(!config.clickable)
+                    {
+                        this.map.on('move', () => this.setCoordinates(this.map.getCenter()));
+                    }
                 }
 
                 this.map.on('moveend', () => setTimeout(() => this.updateLocation(), 500));
@@ -81,8 +95,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 // Geoman setup
                 if (config.geoMan.show) {
-                        this.map.pm.addControls({  
-                            position: config.geoMan.position,  
+                        this.map.pm.addControls({
+                            position: config.geoMan.position,
                             drawCircleMarker: config.geoMan.drawCircleMarker,
                             rotateMode: config.geoMan.rotateMode,
                             drawMarker: config.geoMan.drawMarker,
@@ -93,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             dragMode: config.geoMan.dragMode,
                             cutPolygon: config.geoMan.cutPolygon,
                             editPolygon: config.geoMan.editPolygon,
-                            deleteLayer: config.geoMan.deleteLayer 
+                            deleteLayer: config.geoMan.deleteLayer
                         });
 
                         this.drawItems = new L.FeatureGroup().addTo(this.map);
@@ -137,19 +151,19 @@ document.addEventListener('DOMContentLoaded', () => {
                                             color: config.geoMan.color || "#3388ff",
                                             fillColor: config.geoMan.filledColor || 'blue',
                                             weight: 2,
-                                            fillOpacity: 0.4   
+                                            fillOpacity: 0.4
                                         };
                                     }
                                 },
                                 onEachFeature: (feature, layer) => {
-     
+
                                     if (feature.geometry.type === 'Polygon') {
                                         layer.bindPopup("Polygon Area");
                                     } else if (feature.geometry.type === 'Point') {
                                         layer.bindPopup("Point Location");
                                     }
-                                    
-                   
+
+
                                     if (config.geoMan.editable) {
                                         if (feature.geometry.type === 'Polygon') {
                                             layer.pm.enable({
@@ -161,7 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                             });
                                         }
                                     }
-                        
+
                                     layer.on('pm:edit', () => {
                                         this.updateGeoJson();
                                     });
@@ -176,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                     });
                                 });
                             }
-                            
+
                             this.map.fitBounds(this.drawItems.getBounds());
                     }
               }
@@ -250,6 +264,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 return location;
             },
 
+            setCoordinates: function (coords) {
+
+                $wire.set(config.statePath, {
+                    ...$wire.get(config.statePath),
+                    lat: coords.lat,
+                    lng: coords.lng
+                }, false);
+
+                if (config.liveLocation.send) {
+                    $wire.$refresh();
+                }
+                this.updateMarker();
+                return coords;
+            },
+
             attach: function (el) {
                 this.createMap(el);
                 const observer = new IntersectionObserver(entries => {
@@ -294,16 +323,34 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.map.getContainer().appendChild(locationButton);
             },
 
+            setMarkerRange: function () {
+                distance=parseInt(this.rangeSelectField.value || 0 ) ;
+                if (this.rangeCircle) {
+                    this.rangeCircle.setLatLng(this.getCoordinates()).setRadius(distance);
+                } else {
+                    this.rangeCircle = L.circle(this.getCoordinates(), {
+                        color: 'blue',
+                        fillColor: '#f03',
+                        fillOpacity: 0.5,
+                        radius: distance // The radius in meters
+                    }).addTo(this.map);
+                }
+            },
+
             init: function() {
                 this.$wire = $wire;
                 this.config = config;
                 this.state = state;
+                this.rangeSelectField = document.getElementById(config.rangeSelectField || 'data.distance');
+                let that=this
+                this.rangeSelectField.addEventListener('change', function () {that.updateMarker(); });
                 $wire.on('refreshMap', this.refreshMap.bind(this));
             },
 
             updateMarker: function() {
                 if (config.showMarker) {
                     this.marker.setLatLng(this.getCoordinates());
+                    this.setMarkerRange();
                     setTimeout(() => this.updateLocation(), 500);
                 }
             },

--- a/src/Fields/Map.php
+++ b/src/Fields/Map.php
@@ -30,13 +30,15 @@ class Map extends Field implements MapOptions
         'zoomOffset'           => -1,
         'tileSize'             => 512,
         'detectRetina'         => true,
+        'rangeSelectField'     => 'distance',
         'minZoom'              => 0,
         'maxZoom'              => 28,
         'zoom'                 => 15,
+        'clickable'            => false,
         'markerColor'          => '#3b82f6',
         'liveLocation'         => false,
         'showMyLocationButton' => [false, false, 5000],
-        'default'              => ['lat' => 0 , 'lng' => 0],
+        'default'              => ['lat' => 0, 'lng' => 0],
         'geoMan'               => [
             'show'                  =>  false,
             'editable'              =>  true,
@@ -85,9 +87,13 @@ class Map extends Field implements MapOptions
      */
     public function getMapConfig(): string
     {
+        $statePath = $this->getStatePath();
+        $lastDotPosition = strrpos($statePath, '.');
+        $rangeSelectField = substr($statePath, 0, $lastDotPosition + 1) . $this->mapConfig['rangeSelectField'];
         return json_encode(
             array_merge($this->mapConfig, [
-                'statePath' => $this->getStatePath(),
+                'statePath' => $statePath,
+                'rangeSelectField' => $rangeSelectField,
                 'controls' => array_merge($this->controls, $this->extraControls)
             ])
         );
@@ -103,6 +109,16 @@ class Map extends Field implements MapOptions
         return implode(';', $this->extraStyle);
     }
 
+    /**
+     * Determines if the user can click to place the marker on the map.
+     * @param bool $clickable
+     * @return $this
+     */
+    public function clickable(bool $clickable): self
+    {
+        $this->mapConfig['clickable'] = $clickable;
+        return $this;
+    }
 
     /**
      * Determine if user can drag map around or not.
@@ -195,6 +211,19 @@ class Map extends Field implements MapOptions
     public function tilesUrl(string $url): self
     {
         $this->mapConfig['tilesUrl'] = $url;
+        return $this;
+    }
+
+
+    /**
+     * Use the value of another field on the form for the range of the
+     * circle surrounding the marker
+     * @param string $rangeSelectField,
+     * @param return $this
+     **/
+    public function rangeSelectField(string $rangeSelectField): self
+    {
+        $this->mapConfig['rangeSelectField'] = $rangeSelectField;
         return $this;
     }
 


### PR DESCRIPTION
Hi

This my first contribution to someone else open source work in some time, so please go easy on me. 

I wanted to make a couple of changes so that I could 

1. click on the map to move the marker
2. Have a circle show around the marker that works in tandem with another field in the form that specifies the range.

Both of these should be optional. 

I don't think this should be accepted just yet, but I wanted to see how easy it is to add features, and what kind of testing you might want done. 

The rangeSelectField stuff results in something like this: 
![image](https://github.com/user-attachments/assets/18f18074-eef3-47a0-a6a1-c73eeb4247ad)

Using code like this: 

```php 

            Fieldset::make('Location')
                ->schema([
                    Select::make('membership_distance')
                        ->enum(ClubDistance::class)
                        ->options(ClubDistance::class)
                        ->required(),

                    Map::make('location')
                        ->extraStyles([
                            'min-height: 20vh',
                        ])
                        ->defaultLocation(latitude: 40.4168, longitude: -3.7038)
                        ->liveLocation(true, true, 5000)
                        ->showMarker(true)
                        ->showFullscreenControl(false)
                        ->showZoomControl()
                        ->tilesUrl("https://tile.openstreetmap.de/{z}/{x}/{y}.png")
                        ->zoom(12)
                        ->detectRetina()
                        ->rangeSelectField('membership_distance')
                        ->showMyLocationButton(false)
                        ->drawCircleMarker()
                        ->dragMode(false)
                        ->setFilledColor('#cad9ec'),
                ])
                ->columns(1),
```
