### PR TITLE
feat(bounds): Set bounds for map

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -15,6 +15,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 const that = this;
 
                 this.map = L.map(el, config.controls);
+
+                if(config.bounds)
+                {
+                    let southWest = L.latLng(config.bounds.sw.lat, config.bounds.sw.lng);
+                    let northEast = L.latLng(config.bounds.ne.lat, config.bounds.ne.lng);
+                    let bounds = L.latLngBounds(southWest, northEast);
+                    this.map.setMaxBounds(bounds);
+                    this.map.fitBounds(bounds);
+                    this.map.on('drag', function() {
+                        map.panInsideBounds(bounds, { animate: false });
+                    });
+                }
                 this.map.on('load', () => {
                     setTimeout(() => this.map.invalidateSize(true), 0);
                     if (config.showMarker) {
@@ -81,8 +93,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 // Geoman setup
                 if (config.geoMan.show) {
-                        this.map.pm.addControls({  
-                            position: config.geoMan.position,  
+                        this.map.pm.addControls({
+                            position: config.geoMan.position,
                             drawCircleMarker: config.geoMan.drawCircleMarker,
                             rotateMode: config.geoMan.rotateMode,
                             drawMarker: config.geoMan.drawMarker,
@@ -93,7 +105,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             dragMode: config.geoMan.dragMode,
                             cutPolygon: config.geoMan.cutPolygon,
                             editPolygon: config.geoMan.editPolygon,
-                            deleteLayer: config.geoMan.deleteLayer 
+                            deleteLayer: config.geoMan.deleteLayer
                         });
 
                         this.drawItems = new L.FeatureGroup().addTo(this.map);
@@ -137,19 +149,19 @@ document.addEventListener('DOMContentLoaded', () => {
                                             color: config.geoMan.color || "#3388ff",
                                             fillColor: config.geoMan.filledColor || 'blue',
                                             weight: 2,
-                                            fillOpacity: 0.4   
+                                            fillOpacity: 0.4
                                         };
                                     }
                                 },
                                 onEachFeature: (feature, layer) => {
-     
+
                                     if (feature.geometry.type === 'Polygon') {
                                         layer.bindPopup("Polygon Area");
                                     } else if (feature.geometry.type === 'Point') {
                                         layer.bindPopup("Point Location");
                                     }
-                                    
-                   
+
+
                                     if (config.geoMan.editable) {
                                         if (feature.geometry.type === 'Polygon') {
                                             layer.pm.enable({
@@ -161,7 +173,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                             });
                                         }
                                     }
-                        
+
                                     layer.on('pm:edit', () => {
                                         this.updateGeoJson();
                                     });
@@ -176,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                     });
                                 });
                             }
-                            
+
                             this.map.fitBounds(this.drawItems.getBounds());
                     }
               }

--- a/src/Fields/Map.php
+++ b/src/Fields/Map.php
@@ -35,8 +35,9 @@ class Map extends Field implements MapOptions
         'zoom'                 => 15,
         'markerColor'          => '#3b82f6',
         'liveLocation'         => false,
+        'bounds'               => false,
         'showMyLocationButton' => [false, false, 5000],
-        'default'              => ['lat' => 0 , 'lng' => 0],
+        'default'              => ['lat' => 0, 'lng' => 0],
         'geoMan'               => [
             'show'                  =>  false,
             'editable'              =>  true,
@@ -116,6 +117,46 @@ class Map extends Field implements MapOptions
         return $this;
     }
 
+
+    /**
+     * Prevents the map from panning outside the defined box, and sets
+     * a default location in the center of the box. It makes sense to
+     * use this with a minimum zoom that suits the size of your map and
+     * the size of the box or the way it pans back to the bounding box
+     * looks strange. You can call with $on set to false to undo this.
+     *
+     * @param boolean $on
+     * @param int|float $southWestLat
+     * @param int|float $southWestLng
+     * @param int|float $northEastLat
+     * @param int|float $northEastLng
+     * @return self
+     */
+    public function boundaries(bool $on, int|float $southWestLat = 0, int|float $southWestLng = 0, int|float $northEastLat = 0, int|float $northEastLng = 0): self
+    {
+        if (!$on) {
+            $this->mapConfig['boundaries'] = false;
+
+            return $this;
+        }
+
+        $this->mapConfig['bounds']['sw'] = ['lat' => $southWestLat, 'lng' => $southWestLng];
+        $this->mapConfig['bounds']['ne'] = ['lat' => $northEastLat, 'lng' => $northEastLng];
+        $this->defaultLocation(($southWestLat + $northEastLat) / 2.0, ($southWestLng + $northEastLng) / 2.0);
+
+        return $this;
+    }
+
+    /**
+     * Convenience function for appropriate values for boundaries() when
+     * you want the British Isles
+     * @return self
+     **/
+    public function setBoundsToBritishIsles(): self
+    {
+        $this->boundaries(true, 49.5, -11, 61, 2);
+        return $this;
+    }
 
 
     public function defaultLocation(int|float $latitude, float|int $longitude): self


### PR DESCRIPTION
Using the leaflet setMaxBounds() in order to ensure that users can only select a point within the bounds. Also a convenience function for that the bounds to be the British Isles.

Works with code like this: 

```php 
    public function form(Form $form): Form
    {
        return $form->schema([
            Select::make('membership_distance')
                ->enum(ClubDistance::class)
                ->options(ClubDistance::class)
                ->default(ClubDistance::M5)
                ->required(),

            Map::make('location')
                ->extraStyles([
                    'min-height: 20vh',
                    'max-width:10vw',
                ])
                ->setBoundsToBritishIsles()
                ->showMarker(true)
                ->showFullscreenControl(false)
                ->showZoomControl()
                ->tilesUrl("https://tile.openstreetmap.de/{z}/{x}/{y}.png")
                ->zoom(5)
                ->minZoom(5)
                ->detectRetina()
                ->showMyLocationButton(false)
                ->drawCircleMarker()
                ->dragMode(false)
                ->setFilledColor('#cad9ec'),
        ])->statePath('data');
    }
```