### PR TITLE
Fix: Support for Inline Labels

### DIFF
--- a/resources/views/fields/osm-map-picker.blade.php
+++ b/resources/views/fields/osm-map-picker.blade.php
@@ -1,11 +1,6 @@
-<x-filament-forms::field-wrapper
-    :id="$getId()"
-    :label="$getLabel()"
-    :label-sr-only="$isLabelHidden()"
-    {{-- :helper-text="$getHelperText()" --}}
-    :hint="$getHint()"
-    :required="$isRequired()"
-    :state-path="$getStatePath()"
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
 >
     <div x-data="mapPicker($wire, {{ $getMapConfig() }})"
             x-init="async () => {
@@ -22,4 +17,5 @@
         </div>
         <input type="text" id="{{ $getStatePath() }}_fmrest" style="display:none"/>
     </div>
-</x-filament-forms::field-wrapper>
+</x-dynamic-component>
+


### PR DESCRIPTION
This PR fixes an issue where the inlineLabel() and helperText() methods were not working as expected for the Map field.

The root cause was the manual implementation of the field-wrapper in the Blade component, which omitted several standard Filament attributes. Specifically, :inline-label and :helper-text were not being passed to the wrapper, causing these configurations to be ignored during rendering.

### Changes
Refactored osm-map-picker.blade.php to use the standard Filament pattern for field wrappers.
Replaced the manual x-filament-forms::field-wrapper with x-dynamic-component using :component="$getFieldWrapperView()".
Now passing the entire :field="$field" instance to the wrapper.

### Benefits
**Full Compatibility:** By passing the field instance, the wrapper automatically resolves inlineLabel(), helperText(), hint(), and other standard Filament field features without needing manual attribute mapping.
Extensibility: It now respects custom field wrapper views if defined in the application.
Cleanliness: Reduced boilerplate in the view file by letting Filament's internal logic handle the wrapper properties.

###  Verification Results
Tested by applying ->inlineLabel() and ->helperText('...') to a Map field instance; both now render correctly in the UI.